### PR TITLE
Fix bug causing segfaults with query columns not present in foreign t…

### DIFF
--- a/odbc_fdw.c
+++ b/odbc_fdw.c
@@ -1223,7 +1223,7 @@ odbcIterateForeignScan(ForeignScanState *node)
         SQLSMALLINT	NullablePtr;
         int i;
         int k;
-        bool found = FALSE;
+        bool found;
 
         /* Allocate memory for the masks */
         col_position_mask = NIL;
@@ -1232,6 +1232,7 @@ odbcIterateForeignScan(ForeignScanState *node)
         /* Obtain the column information of the first row. */
         for (i = 1; i <= columns; i++)
         {
+            found = FALSE;
             ColumnName = (SQLCHAR *) palloc(sizeof(SQLCHAR) * 255);
             SQLDescribeCol(stmt,
                            i,						/* ColumnName */


### PR DESCRIPTION
Fix bug causing segfaults with query columns not present in foreign table

The `found` variable retained the last column value as default value for next column, so missing columns where not detected and the size of the col_position_mask and col_size_array could be inconsistent with the number of columns.