### PR TITLE
Fix server segfault bugs

### DIFF
--- a/odbc_fdw.c
+++ b/odbc_fdw.c
@@ -1286,7 +1286,7 @@ odbcIterateForeignScan(ForeignScanState *node)
     {
         num_of_result_cols = festate->num_of_result_cols;
         col_position_mask = list_copy(festate->col_position_mask);
-        col_size_array = festate->col_size_array;
+        col_size_array = list_copy(festate->col_size_array);
     }
 
     ExecClearTuple(slot);

--- a/odbc_fdw.c
+++ b/odbc_fdw.c
@@ -1321,7 +1321,7 @@ odbcBeginForeignScan(ForeignScanState *node, int eflags)
 static TupleTableSlot *
 odbcIterateForeignScan(ForeignScanState *node)
 {
-    EState	   *estate = node->ss.ps.state;
+    EState *executor_state = node->ss.ps.state;
     MemoryContext prev_context;
     /* ODBC API return status */
     SQLRETURN ret;
@@ -1370,7 +1370,7 @@ odbcIterateForeignScan(ForeignScanState *node)
 
         /* Allocate memory for the masks in a memory context that
            persists between IterateForeignScan calls */
-        prev_context = MemoryContextSwitchTo(estate->es_query_cxt);
+        prev_context = MemoryContextSwitchTo(executor_state->es_query_cxt);
         col_position_mask = NIL;
         col_size_array = NIL;
         num_of_result_cols = columns;

--- a/odbc_fdw.c
+++ b/odbc_fdw.c
@@ -1319,11 +1319,11 @@ odbcIterateForeignScan(ForeignScanState *node)
             if (mapped_pos == -1)
                 continue;
 
-            buf = (char *) palloc(sizeof(char) * col_size);
+            buf = (char *) palloc(sizeof(char) * (col_size+1));
 
-            /* retrieve column data as a string */
+            /* retrieve column data as a zero-terminated string */
             ret = SQLGetData(stmt, i, SQL_C_CHAR,
-                             buf, sizeof(char) * col_size, &indicator);
+                             buf, sizeof(char) * (col_size+1), &indicator);
 
             if (SQL_SUCCEEDED(ret))
             {

--- a/odbc_fdw.c
+++ b/odbc_fdw.c
@@ -135,7 +135,7 @@ static void odbcGetForeignRelSize(PlannerInfo *root, RelOptInfo *baserel, Oid fo
 static void odbcEstimateCosts(PlannerInfo *root, RelOptInfo *baserel, Cost *startup_cost, Cost *total_cost, Oid foreigntableid);
 static void odbcGetForeignPaths(PlannerInfo *root, RelOptInfo *baserel, Oid foreigntableid);
 static bool odbcAnalyzeForeignTable(Relation relation, AcquireSampleRowsFunc *func, BlockNumber *totalpages);
-static ForeignScan* odbcGetForeignPlan(PlannerInfo *root, RelOptInfo *baserel, Oid foreigntableid, ForeignPath *best_path, List *tlist, List *scan_clauses);
+static ForeignScan* odbcGetForeignPlan(PlannerInfo *root, RelOptInfo *baserel, Oid foreigntableid, ForeignPath *best_path, List *tlist, List *scan_clauses, Plan *outer_plan);
 /* routines for versions older than 9.2.0 */
 #else
 static FdwPlan *odbcPlanForeignScan(Oid foreigntableid, PlannerInfo *root, RelOptInfo *baserel);
@@ -841,8 +841,8 @@ static bool odbcAnalyzeForeignTable(Relation relation, AcquireSampleRowsFunc *fu
 	return false;
 }
 
-static ForeignScan* odbcGetForeignPlan(PlannerInfo *root, RelOptInfo *baserel, 
-	Oid foreigntableid, ForeignPath *best_path, List *tlist, List *scan_clauses)
+static ForeignScan* odbcGetForeignPlan(PlannerInfo *root, RelOptInfo *baserel,
+	Oid foreigntableid, ForeignPath *best_path, List *tlist, List *scan_clauses, Plan *outer_plan)
 {
 	Index scan_relid = baserel->relid;
 	#ifdef DEBUG

--- a/odbc_fdw.c
+++ b/odbc_fdw.c
@@ -1328,14 +1328,21 @@ odbcIterateForeignScan(ForeignScanState *node)
             if (SQL_SUCCEEDED(ret))
             {
                 /* Handle null columns */
-                if (indicator == SQL_NULL_DATA) strcpy(buf, "NULL");
-                initStringInfo(&col_data);
-                appendStringInfoString (&col_data, buf);
+                if (indicator == SQL_NULL_DATA)
+                {
+                  // BuildTupleFromCStrings expects NULLs to be NULL pointers
+                  values[mapped_pos] = NULL;
+                }
+                else
+                {
+                  initStringInfo(&col_data);
+                  appendStringInfoString (&col_data, buf);
 
                 values[mapped_pos] = col_data.data;
 #ifdef DEBUG
                 elog(NOTICE, "values[%i] = %s", mapped_pos, values[mapped_pos]);
 #endif
+                }
             }
             pfree(buf);
         }

--- a/odbc_fdw.c
+++ b/odbc_fdw.c
@@ -185,19 +185,19 @@ odbc_fdw_handler(PG_FUNCTION_ARGS)
 Datum
 odbc_fdw_validator(PG_FUNCTION_ARGS)
 {
-    List	*options_list = untransformRelOptions(PG_GETARG_DATUM(0));
-    Oid		catalog = PG_GETARG_OID(1);
-    char	*dsn = NULL;
-    char	*driver = NULL;
-    char	*svr_host = NULL;
-    char	*svr_port = NULL;
-    char	*svr_database = NULL;
-    char	*svr_schema = NULL;
-    char	*svr_table = NULL;
-    char	*sql_query = NULL;
-    char	*sql_count = NULL;
-    char	*username = NULL;
-    char	*password = NULL;
+    List  *options_list = untransformRelOptions(PG_GETARG_DATUM(0));
+    Oid   catalog = PG_GETARG_OID(1);
+    char  *dsn          = NULL;
+    char  *driver       = NULL;
+    char  *svr_host     = NULL;
+    char  *svr_port     = NULL;
+    char  *svr_database = NULL;
+    char  *svr_schema   = NULL;
+    char  *svr_table    = NULL;
+    char  *sql_query    = NULL;
+    char  *sql_count    = NULL;
+    char  *username     = NULL;
+    char  *password     = NULL;
     ListCell	*cell;
 
 #ifdef DEBUG

--- a/odbc_fdw.c
+++ b/odbc_fdw.c
@@ -815,8 +815,8 @@ static void odbcGetForeignPaths(PlannerInfo *root, RelOptInfo *baserel, Oid fore
 	
 	add_path(baserel, 
 		(Path *) create_foreignscan_path(root, baserel, baserel->rows, startup_cost, total_cost,
-			NIL, NULL, NIL, NIL /* no fdw_private list */));
-	
+			NIL, NULL, NULL, NIL /* no fdw_private list */));
+
 	#ifdef DEBUG
 		ereport(NOTICE,
 			(errmsg("----> finishing odbcGetForeignPaths")
@@ -862,7 +862,7 @@ static ForeignScan* odbcGetForeignPlan(PlannerInfo *root, RelOptInfo *baserel,
 	return make_foreignscan(tlist, scan_clauses,
                                 scan_relid, NIL, NIL,
                                 NIL /* fdw_scan_tlist */, NIL, /* fdw_recheck_quals */
-                                NIL /* outer_plan */ );
+                                NULL /* outer_plan */ );
 }
 
 /* routines for versions older than 9.2.0 */

--- a/odbc_fdw.c
+++ b/odbc_fdw.c
@@ -349,7 +349,7 @@ odbc_fdw_validator(PG_FUNCTION_ARGS)
     if (!dsn && !driver && catalog == ForeignServerRelationId)
         ereport(ERROR,
                 (errcode(ERRCODE_SYNTAX_ERROR),
-                 errmsg("missing eaaential information: dsn (Database Source Name) or driver")
+                 errmsg("missing essential information: dsn (Database Source Name) or driver")
                 ));
 
 

--- a/odbc_fdw.c
+++ b/odbc_fdw.c
@@ -356,7 +356,17 @@ odbc_fdw_validator(PG_FUNCTION_ARGS)
     PG_RETURN_VOID();
 }
 
-
+/*
+ * Replace empty string by null pointer
+ */
+static void
+normalizeEmptyString(char **str)
+{
+  if (*str && !**str)
+  {
+    *str = NULL;
+  }
+}
 
 /*
  * Fetch the options for a odbc_fdw foreign table.
@@ -465,43 +475,18 @@ odbcGetOptions(Oid foreigntableid, char **svr_dsn, char **svr_driver, char **svr
     //elog(NOTICE, "list length: %i", (*mapping_list)->length);
 #endif
 
-    /* Default values, if required */
-    if (!*svr_dsn)
-        *svr_dsn = NULL;
-
-    if (!*svr_driver)
-        *svr_driver = NULL;
-
-    if (!*svr_host)
-        *svr_host = NULL;
-
-    if (!*svr_port)
-        *svr_port = NULL;
-
-    if (!*svr_database)
-        *svr_database = NULL;
-
-    if (!*svr_schema)
-        *svr_schema = NULL;
-
-    if (!*svr_table)
-        *svr_table = NULL;
-
-    if (!*sql_query)
-    {
-        *sql_query = NULL;
-    }
-
-    if (!*sql_count)
-    {
-        *sql_count = NULL;
-    }
-
-    if (!*username)
-        *username = NULL;
-
-    if (!*password)
-        *password = NULL;
+    /* Convert empty strings to NULL pointers */
+    normalizeEmptyString(svr_dsn);
+    normalizeEmptyString(svr_driver);
+    normalizeEmptyString(svr_host);
+    normalizeEmptyString(svr_port);
+    normalizeEmptyString(svr_database);
+    normalizeEmptyString(svr_schema);
+    normalizeEmptyString(svr_table);
+    normalizeEmptyString(sql_query);
+    normalizeEmptyString(sql_count);
+    normalizeEmptyString(username);
+    normalizeEmptyString(password);
 }
 
 #ifdef DEBUG


### PR DESCRIPTION
Here we're debugging a number of problems found when prototyping CartoDB connectors using this fdw and a MySQL ODBC driver. 

Errors which brought down the PostgreSQL server were occurring in many cases (e.g. when queries have column names not present in the foreign table, when when reading more than just a few rows, etc.).