### PR TITLE
Handle single quotes when quoting options

### DIFF
--- a/odbc_fdw.c
+++ b/odbc_fdw.c
@@ -1572,6 +1572,38 @@ odbcReScanForeignScan(ForeignScanState *node)
 }
 
 
+static const char*
+quotedString(const char* text)
+{
+	static StringInfoData buffer;
+	static const char SINGLE_QUOTE = '\'';
+	const char *p;
+
+	initStringInfo(&buffer);
+	appendStringInfoChar(&buffer, SINGLE_QUOTE);
+
+    while (*text)
+	{
+		p = text;
+		while (*p && *p != SINGLE_QUOTE)
+		{
+			p++;
+		}
+	    appendBinaryStringInfo(&buffer, text, p-text);
+		if (*p == SINGLE_QUOTE)
+		{
+			appendStringInfoChar(&buffer, SINGLE_QUOTE);
+			appendStringInfoChar(&buffer, SINGLE_QUOTE);
+			p++;
+		}
+		text = p;
+	}
+
+	appendStringInfoChar(&buffer, SINGLE_QUOTE);
+
+	return buffer.data;
+}
+
 static void
 appendOption(StringInfo str, bool first, const char* option_name, const char* option_value)
 {
@@ -1579,7 +1611,7 @@ appendOption(StringInfo str, bool first, const char* option_name, const char* op
 	{
 		appendStringInfo(str, ",\n");
 	}
-	appendStringInfo(str, "%s '%s'", option_name, option_value);
+	appendStringInfo(str, "%s %s", option_name, quotedString(option_value));
 }
 
 List *

--- a/odbc_fdw.c
+++ b/odbc_fdw.c
@@ -1589,7 +1589,7 @@ quotedString(const char* text)
 		{
 			p++;
 		}
-	    appendBinaryStringInfo(&buffer, text, p-text);
+	    appendBinaryStringInfo(&buffer, text, p - text);
 		if (*p == SINGLE_QUOTE)
 		{
 			appendStringInfoChar(&buffer, SINGLE_QUOTE);

--- a/odbc_fdw.c
+++ b/odbc_fdw.c
@@ -222,10 +222,10 @@ copy_odbcFdwOptions(odbcFdwOptions* to, odbcFdwOptions* from)
 /*
  * Avoid NULL string: return original string, or empty string if NULL
  */
-static char*
+static const char*
 empty_string_if_null(char *string)
 {
-	static char* empty_string = "";
+	static const char* empty_string = "";
 	return string == NULL ? empty_string : string;
 }
 

--- a/odbc_fdw.c
+++ b/odbc_fdw.c
@@ -1572,15 +1572,13 @@ odbcReScanForeignScan(ForeignScanState *node)
 }
 
 
-static const char*
-quotedString(const char* text)
+static void
+appendQuotedString(StringInfo buffer, const char* text)
 {
-	static StringInfoData buffer;
 	static const char SINGLE_QUOTE = '\'';
 	const char *p;
 
-	initStringInfo(&buffer);
-	appendStringInfoChar(&buffer, SINGLE_QUOTE);
+	appendStringInfoChar(buffer, SINGLE_QUOTE);
 
     while (*text)
 	{
@@ -1589,19 +1587,17 @@ quotedString(const char* text)
 		{
 			p++;
 		}
-	    appendBinaryStringInfo(&buffer, text, p - text);
+	    appendBinaryStringInfo(buffer, text, p - text);
 		if (*p == SINGLE_QUOTE)
 		{
-			appendStringInfoChar(&buffer, SINGLE_QUOTE);
-			appendStringInfoChar(&buffer, SINGLE_QUOTE);
+			appendStringInfoChar(buffer, SINGLE_QUOTE);
+			appendStringInfoChar(buffer, SINGLE_QUOTE);
 			p++;
 		}
 		text = p;
 	}
 
-	appendStringInfoChar(&buffer, SINGLE_QUOTE);
-
-	return buffer.data;
+	appendStringInfoChar(buffer, SINGLE_QUOTE);
 }
 
 static void
@@ -1611,7 +1607,8 @@ appendOption(StringInfo str, bool first, const char* option_name, const char* op
 	{
 		appendStringInfo(str, ",\n");
 	}
-	appendStringInfo(str, "%s %s", option_name, quotedString(option_value));
+	appendStringInfo(str, "%s ", option_name);
+	appendQuotedString(str, option_value);
 }
 
 List *


### PR DESCRIPTION
Option values are quoted in SQL statements.
If an option value contains single quotes they must
be duplicated as a way of escaping them.

Fixes #19