### PR TITLE
Quote options to preserve case

### DIFF
--- a/odbc_fdw.c
+++ b/odbc_fdw.c
@@ -1893,7 +1893,7 @@ appendOption(StringInfo str, bool first, const char* option_name, const char* op
 	{
 		appendStringInfo(str, ",\n");
 	}
-	appendStringInfo(str, "%s ", option_name);
+	appendStringInfo(str, "\"%s\" ", option_name);
 	appendQuotedString(str, option_value);
 }
 


### PR DESCRIPTION
The option names where downcased in the CREATE FOREIGN TABLE generated by IMPORT FOREIGN SCHMA.

This can be a problem for drivers with case-sensitive options.