### PR TITLE
Preliminary support for PostgreSQL 10

### DIFF
--- a/odbc_fdw.c
+++ b/odbc_fdw.c
@@ -947,7 +947,7 @@ odbc_table_size(PG_FUNCTION_ARGS)
   unsigned int tableSize;
   List *tableOptions = NIL;
   Node *val = (Node *) makeString(tableName);
-#if PG_VERSION_NUM >= 10000
+#if PG_VERSION_NUM >= 100000
   DefElem *elem = (DefElem *) makeDefElem(defname, val, -1);
 #else
   DefElem *elem = (DefElem *) makeDefElem(defname, val);
@@ -971,7 +971,7 @@ odbc_query_size(PG_FUNCTION_ARGS)
   unsigned int querySize;
   List *queryOptions = NIL;
   Node *val = (Node *) makeString(sqlQuery);
-#if PG_VERSION_NUM >= 10000
+#if PG_VERSION_NUM >= 100000
   DefElem *elem = (DefElem *) makeDefElem(defname, val, -1);
 #else
   DefElem *elem = (DefElem *) makeDefElem(defname, val);


### PR DESCRIPTION
This patch makes the odbc compile against PostgreSQL 10 and also able to query tables.

There are some rough spots like the IMPORT FOREIGN SCHEMA , when importing a batch of tables I'll tackle next (single table import seems to work fine).  

Also cleaned up a couple of warnings with unsigned int use and missing change for 9.6.

I sent a request for CLA.