### PR TITLE
 Ignore mingw64, windows, and Mac build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Generated subdirectories
 .DS_Store
 test/results/
+*.a
+*.dll
+*.dylib
 **/*.o
 **/*.so
 test/regression.diffs


### PR DESCRIPTION
When I compiled under mingw64 (building for windows), it generates a libodbc_fdw.a and odbc_fdw.dll at the root of tree.  For extra measure I added .dylib since I think MacOSX generates those.  I don't have a Mac to test that.

This patch  is to ignore these build artifacts from being accidentally committed.