### PR TITLE
Add the carto-package.json file

### DIFF
--- a/carto-package.json
+++ b/carto-package.json
@@ -1,0 +1,14 @@
+{
+    "name": "postgis",
+    "current_version": {
+        "requires": {
+            "postgres": ">=10.1.1"
+        },
+        "works_with": {
+            "builder": ">=4.12.74"
+        }
+    },
+
+    "exceptional_versions": {
+    }
+}

--- a/carto-package.json
+++ b/carto-package.json
@@ -1,5 +1,5 @@
 {
-    "name": "postgis",
+    "name": "odbc_fdw",
     "current_version": {
         "requires": {
             "postgres": ">=10.1.1"

--- a/carto-package.json
+++ b/carto-package.json
@@ -5,7 +5,6 @@
             "postgres": ">=10.1.1"
         },
         "works_with": {
-            "builder": ">=4.12.74"
         }
     },
 


### PR DESCRIPTION
I added postgres 10.1.1 in reference to our fork. Although it shall be
possible to build against 9.5+ versions, some of them are known to
have subtle failures. See
https://github.com/CartoDB/odbc_fdw/issues/71 for an example

Mind that the intent of this file is the automation of the on-premise
dependencies and packaging. So instead of trying to cover all the
cases we shall focus on solving the problem at hand.