### PR TITLE
Support for PostgreSQL 11 ExplainPropertyLong -> ExplainPropertyInteger

### DIFF
--- a/odbc_fdw.c
+++ b/odbc_fdw.c
@@ -1782,7 +1782,11 @@ odbcExplainForeignScan(ForeignScanState *node, ExplainState *es)
 	/* Suppress file size if we're not showing cost details */
 	if (es->costs)
 	{
+#if PG_VERSION_NUM >= 110000
+		ExplainPropertyInteger("Foreign Table Size", "b", table_size, es);
+#else
 		ExplainPropertyLong("Foreign Table Size", table_size, es);
+#endif
 	}
 }
 


### PR DESCRIPTION
ExplainPropertyLong was removed in PostgreSQL 11 and ExplainPropertyInteger was expanded to handle longs