### PR TITLE
Fix columns iteration

### DIFF
--- a/odbc_fdw.c
+++ b/odbc_fdw.c
@@ -2135,7 +2135,7 @@ odbcImportForeignSchema(ImportForeignSchemaStmt *stmt, Oid serverOid)
 			i = 0;
 			initStringInfo(&col_str);
 			ColumnName = (SQLCHAR *) palloc(sizeof(SQLCHAR) * MAXIMUM_COLUMN_NAME_LEN);
-			while (SQL_SUCCESS == ret)
+			while (SQL_NO_DATA != ret && SQL_SUCCESS_WITH_INFO != ret)
 			{
 				ret = SQLFetch(columns_stmt);
 				if (SQL_SUCCESS == ret)
@@ -2162,6 +2162,24 @@ odbcImportForeignSchema(ImportForeignSchemaStmt *stmt, Oid serverOid)
 					}
 					appendStringInfo(&col_str, "\"%s\" %s", ColumnName, (char *) sql_type.data);
 				}
+				#ifdef DEBUG
+				if (ret == SQL_ERROR || ret == SQL_SUCCESS_WITH_INFO)
+				{
+					SQLINTEGER   j = 1;
+					SQLINTEGER   native;
+					SQLCHAR  state[ 7 ];
+					SQLCHAR  text[256];
+					SQLSMALLINT  len;
+					SQLRETURN    diag_ret;
+					do
+					{
+				        diag_ret = SQLGetDiagRec(SQL_HANDLE_STMT, columns_stmt, j++, state, &native, text, sizeof(text), &len);
+						if (SQL_SUCCEEDED(diag_ret))
+							elog(DEBUG1, "FETCHING %s:%ld:%ld:%s\n", state, (long int) j, (long int) native, text);
+					}
+					while( diag_ret == SQL_SUCCESS );
+				}
+				#endif
 			}
 			SQLCloseCursor(columns_stmt);
 			SQLFreeHandle(SQL_HANDLE_STMT, columns_stmt);


### PR DESCRIPTION
We've had cases of empty column lists in some cases with the ODBC drivers for BigQuery and Snowflake.

After some debugging with the latter, it seems that column iteration may be interrupted by `SQLFetch` erros responses like these:

```
DEBUG:   HY000:0:6:[Snowflake][Snowflake] (6)
      Assertion failure: GEOGRAPHY_type_unsupported
```

```
DEBUG:  FETCHING HY000:2:6:[Snowflake][Snowflake] (6)
      Assertion failure: USER_DEFINED_TYPE_type_unsupported
```

With this patch those errors are ignored (skipping columns of unsupported types) and the iteration is resumed.