### PR TITLE
Map varchar(0) to text

### DIFF
--- a/odbc_fdw.c
+++ b/odbc_fdw.c
@@ -1646,6 +1646,10 @@ odbcIterateForeignScan(ForeignScanState *node)
 			int mapped_pos = list_nth_int(col_position_mask, mask_index);
 			ColumnConversion conversion = list_nth_int(col_conversion_array, mask_index);
 
+			if (col_size == 0) {
+				col_size = 1024;
+			}
+
 			/* Ignore this column if position is marked as invalid */
 			if (mapped_pos == -1)
 				continue;

--- a/odbc_fdw.c
+++ b/odbc_fdw.c
@@ -571,7 +571,7 @@ sql_data_type(
 		break;
 	case SQL_VARCHAR :
 	case SQL_WVARCHAR :
-		if (column_size <= 255)
+		if (column_size <= 255 && column_size > 0)
 		{
 			appendStringInfo(sql_type, "varchar(%u)", (unsigned)column_size);
 		}


### PR DESCRIPTION
Fixes #59

Some text types are mapped by ODBC drivers to VARCHAR(0) which is not valid in Postgres. Now we map such cases to `text`.