### PR TITLE
Improve error messages

### DIFF
--- a/test/expected/postgres_20_query_test.out
+++ b/test/expected/postgres_20_query_test.out
@@ -11,7 +11,9 @@ SELECT * FROM query_postgres_test_table;
 (1 row)
 
 SELECT * FROM existent_table_in_schema_public;
-ERROR:  Executing ODBC query
+ERROR:  Executing ODBC query to get table size
+ERROR: relation "nonexistent_schema.existent_table_in_schema_public" does not exist;
+Error while executing the query
 SELECT * FROM test_table_in_schema;
  id |  data   
 ----+---------


### PR DESCRIPTION
When an error occurs in a ODBC call, we were only producing generic error messages about what we we're trying to do.
With this patch we now also include information about the error provided by the ODBC driver.

This is to support https://app.clubhouse.io/cartoteam/story/80914/improve-error-messages-while-importing

For example, if a SQL query executed (via `sql_quey` in IMPORT FOREIGN SCHEMA) was syntactically incorrect, we had:

```
ERROR:  Executing ODBC query
```

With the extension compiled with debug information and debug messages on we had some additional information, but not as part of the error message:

```
DEBUG:  Error result (-1): Executing ODBC query
DEBUG:   42000:1:1003:SQL compilation error:
syntax error line 1 at position 51 unexpected '10'.

ERROR:  Executing ODBC query
```

Now we have the same information in the DEBUG log appendend to the error message:

```
ERROR:  Executing ODBC query to get schema
SQL compilation error:
syntax error line 1 at position 51 unexpected '10'.
```

This will allow for better error messages in the CARTO Import API: see https://app.clubhouse.io/cartoteam/story/80914/improve-error-messages-while-importing 