### PR TITLE
Fix potential privacy problem.

### DIFF
--- a/odbc_fdw.c
+++ b/odbc_fdw.c
@@ -2229,12 +2229,16 @@ odbcImportForeignSchema(ImportForeignSchemaStmt *stmt, Oid serverOid)
 		foreach(option, stmt->options)
 		{
 			DefElem *def = (DefElem *) lfirst(option);
+#if PG_VERSION_NUM >= 100000
 			// options not in the CREATE FOREIGN TABLE statement will have location == -1
 			// we'll ignore them as they are defined by the SERVER or USER MAPPING, and including them here
 			// would be functional but could expose sensitive information
 			if (def->location != -1) {
 				appendOption(&create_statement, ++option_count == 1, def->defname, defGetString(def));
 			}
+#else
+			appendOption(&create_statement, ++option_count == 1, def->defname, defGetString(def));
+#endif
 		}
 		if (is_blank_string(options.table))
 		{

--- a/odbc_fdw.c
+++ b/odbc_fdw.c
@@ -2229,7 +2229,12 @@ odbcImportForeignSchema(ImportForeignSchemaStmt *stmt, Oid serverOid)
 		foreach(option, stmt->options)
 		{
 			DefElem *def = (DefElem *) lfirst(option);
-			appendOption(&create_statement, ++option_count == 1, def->defname, defGetString(def));
+			// options not in the CREATE FOREIGN TABLE statement will have location == -1
+			// we'll ignore them as they are defined by the SERVER or USER MAPPING, and including them here
+			// would be functional but could expose sensitive information
+			if (def->location != -1) {
+				appendOption(&create_statement, ++option_count == 1, def->defname, defGetString(def));
+			}
 		}
 		if (is_blank_string(options.table))
 		{


### PR DESCRIPTION
The CREATE FOREIGN TABLE statements generated by IMPORT FOREIGN SCHEMA contain all the OPTIONS defined in the corresponding SERVER and USER MAPPING. 

This is a potencial privacy problem, since USER MAPPING options can be confidential (passwords, ...) and when they are inserted in an statement to be executed the could be revealed through error (or debug) messages.
