### PR TITLE
Fix separation of columns

### DIFF
--- a/odbc_fdw.c
+++ b/odbc_fdw.c
@@ -2061,9 +2061,10 @@ odbcImportForeignSchema(ImportForeignSchemaStmt *stmt, Oid serverOid)
 				if (SQL_SUCCESS == ret)
 				{
 					int excluded = false;
+					SQLRETURN getdata_ret;
 					TableName = (SQLCHAR *) palloc(sizeof(SQLCHAR) * MAXIMUM_TABLE_NAME_LEN);
-					ret = SQLGetData(tables_stmt, SQLTABLES_NAME_COLUMN, SQL_C_CHAR, TableName, MAXIMUM_TABLE_NAME_LEN, &indicator);
-					check_return(ret, "Reading table name", tables_stmt, SQL_HANDLE_STMT);
+					getdata_ret = SQLGetData(tables_stmt, SQLTABLES_NAME_COLUMN, SQL_C_CHAR, TableName, MAXIMUM_TABLE_NAME_LEN, &indicator);
+					check_return(getdata_ret, "Reading table name", tables_stmt, SQL_HANDLE_STMT);
 
 					/* Since we're not filtering the SQLTables call by schema
 					   we must exclude here tables that belong to other schemas.
@@ -2072,8 +2073,8 @@ odbcImportForeignSchema(ImportForeignSchemaStmt *stmt, Oid serverOid)
 					   So we only reject tables for which the schema is not
 					   blank and different from the desired schema:
 					 */
-					ret = SQLGetData(tables_stmt, SQLTABLES_SCHEMA_COLUMN, SQL_C_CHAR, table_schema, MAXIMUM_SCHEMA_NAME_LEN, &indicator);
-					if (SQL_SUCCESS == ret)
+					getdata_ret = SQLGetData(tables_stmt, SQLTABLES_SCHEMA_COLUMN, SQL_C_CHAR, table_schema, MAXIMUM_SCHEMA_NAME_LEN, &indicator);
+					if (SQL_SUCCESS == getdata_ret)
 					{
 						if (!is_blank_string((char*)table_schema) && strcmp((char*)table_schema, schema_name) )
 						{

--- a/odbc_fdw.c
+++ b/odbc_fdw.c
@@ -1950,6 +1950,7 @@ odbcImportForeignSchema(ImportForeignSchemaStmt *stmt, Oid serverOid)
 	SQLLEN indicator;
 	const char* schema_name;
 	bool missing_foreign_schema = false;
+	bool first_column = true;
 
 	elog_debug("%s", __func__);
 
@@ -2008,10 +2009,15 @@ odbcImportForeignSchema(ImportForeignSchemaStmt *stmt, Oid serverOid)
 				elog(NOTICE, "Data type not supported (%d) for column %s", DataType, ColumnName);
 				continue;
 			}
-			if (i > 1)
+			if (!first_column)
 			{
 				appendStringInfo(&col_str, ", ");
 			}
+			else
+			{
+				first_column = false;
+			}
+
 			appendStringInfo(&col_str, "\"%s\" %s", ColumnName, (char *) sql_type.data);
 		}
 		SQLCloseCursor(query_stmt);

--- a/test/expected/sqlserver_20_query_test.out
+++ b/test/expected/sqlserver_20_query_test.out
@@ -22,3 +22,8 @@ SELECT * FROM ODBCQuerySize('sqlserver_fdw', 'select * from sqlserver_test_table
              1
 (1 row)
 
+SELECT * FROM sqlserver_test_table_with_unsupported_initial_column;
+ id | name
+----+------
+  1 | aaaa
+(1 row)

--- a/test/expected/sqlserver_20_query_test.out
+++ b/test/expected/sqlserver_20_query_test.out
@@ -27,3 +27,4 @@ SELECT * FROM sqlserver_test_table_with_unsupported_initial_column;
 ----+------
   1 | aaaa
 (1 row)
+

--- a/test/fixtures/sqlserver_fixtures.sql
+++ b/test/fixtures/sqlserver_fixtures.sql
@@ -22,5 +22,9 @@ begin
 -- Create fixture
     create table sqlserver_test_table(id int, name text);
     insert into sqlserver_test_table values (1, 'aaaa');
+
+    create table sqlserver_test_table_with_unsupported_initial_column(ignored varbinary(10), id int, name text);
+    insert into sqlserver_test_table_with_unsupported_initial_column(id, name) values (1, 'aaaa');
+
 end
 go

--- a/test/sql/sqlserver_20_query_test_disabled.sql
+++ b/test/sql/sqlserver_20_query_test_disabled.sql
@@ -2,3 +2,4 @@ SELECT * FROM sqlserver_test_table;
 SELECT * FROM ODBCTablesList('sqlserver_fdw', 1);
 SELECT * FROM ODBCTableSize('sqlserver_fdw', 'sqlserver_test_table');
 SELECT * FROM ODBCQuerySize('sqlserver_fdw', 'select * from sqlserver_test_table');
+SELECT * FROM sqlserver_test_table_with_unsupported_initial_column;

--- a/test/template/sqlserver_installation_test.tpl
+++ b/test/template/sqlserver_installation_test.tpl
@@ -16,3 +16,4 @@ IMPORT FOREIGN SCHEMA dbo
   OPTIONS(
     ApplicationIntent 'ReadOnly'
 );
+-- !OUTPUT! NOTICE:  Data type not supported (-3) for column ignored


### PR DESCRIPTION
The comma-separation of columns was incorrect if the first column was skipped due to unsupported type (so a leading coman would appear: `,col1,col2`.
